### PR TITLE
Remove ctrl-g for searching

### DIFF
--- a/鼠标配合-家庭.ahk
+++ b/鼠标配合-家庭.ahk
@@ -65,14 +65,6 @@ k::up
 ^d::TrayTip "本脚本在Chrome里禁用了Control+d。如果要添加到收藏夹，请使用鼠标。", "屏蔽误操作", 1
 #hotif 
 
-
-#hotif ! WinActive("ahk_exe putty.exe")
-;ctrl+g 用google搜索剪贴板关键词
-^g::run "https://www.google.com/search?q=" . A_Clipboard
-#hotif
-
-
-
 GetModuleFileNameEx( p_pid ) ; by shimanov -  www.autohotkey.com/forum/viewtopic.php?t=9000
 {
    local h_process, name_size, result, name


### PR DESCRIPTION
It's not used at all but can be mis-triggered.


undo ccd29e638510e8e54c298d9e68ca5f92e14e56cc